### PR TITLE
Fixed failing tests due to missing methods

### DIFF
--- a/source/Teapot-Core/TeaMethodMatcher.class.st
+++ b/source/Teapot-Core/TeaMethodMatcher.class.st
@@ -25,6 +25,11 @@ TeaMethodMatcher class >> exactly: aSymbol [
 		name: aSymbol asString
 ]
 
+{ #category : #converting }
+TeaMethodMatcher >> asString [
+	^ name
+]
+
 { #category : #'http method matcher' }
 TeaMethodMatcher >> matchesHttpMethod: aSymbol [
 	^ matcherBlock value: aSymbol

--- a/source/Teapot-Core/TeaRequestMatcher.class.st
+++ b/source/Teapot-Core/TeaRequestMatcher.class.st
@@ -35,6 +35,11 @@ TeaRequestMatcher >> matchesUrl: aZnUrl [
 	^ urlPattern matchesUrl: aZnUrl placeholders: Dictionary new
 ]
 
+{ #category : #accessing }
+TeaRequestMatcher >> methodMatcher [
+	^ methodMatcher
+]
+
 { #category : #printing }
 TeaRequestMatcher >> printOn: aStream [
 	methodMatcher printOn: aStream.

--- a/source/Teapot-Tools/TeaMethodMatcher.extension.st
+++ b/source/Teapot-Tools/TeaMethodMatcher.extension.st
@@ -1,6 +1,0 @@
-Extension { #name : #TeaMethodMatcher }
-
-{ #category : #'*Teapot-Tools' }
-TeaMethodMatcher >> asString [
-	^ name
-]

--- a/source/Teapot-Tools/TeaRequestMatcher.extension.st
+++ b/source/Teapot-Tools/TeaRequestMatcher.extension.st
@@ -1,11 +1,6 @@
 Extension { #name : #TeaRequestMatcher }
 
 { #category : #'*Teapot-Tools' }
-TeaRequestMatcher >> methodMatcher [
-	^ methodMatcher
-]
-
-{ #category : #'*Teapot-Tools' }
 TeaRequestMatcher >> urlPattern [
 	^ urlPattern
 ]


### PR DESCRIPTION
Moved TeaMethodMatcher>>#asString and TeaRequestMatcher>>#methodMatcher extensions to the core as they are being used within the Tea405AwareNotFoundHandler