### PR TITLE
Fixed tools on Pharo 6.1

### DIFF
--- a/source/Teapot-Tools/TeaFormTab.class.st
+++ b/source/Teapot-Tools/TeaFormTab.class.st
@@ -3,7 +3,7 @@ I'm built up from a dynamically extensible key value pair list (TeaKeyValueInput
 "
 Class {
 	#name : #TeaFormTab,
-	#superclass : #ComposablePresenter,
+	#superclass : #ComposableModel,
 	#instVars : [
 		'form',
 		'addButton'

--- a/source/Teapot-Tools/TeaKeyValueInput.class.st
+++ b/source/Teapot-Tools/TeaKeyValueInput.class.st
@@ -3,7 +3,7 @@ Two inputs and a remove button.
 "
 Class {
 	#name : #TeaKeyValueInput,
-	#superclass : #ComposablePresenter,
+	#superclass : #ComposableModel,
 	#instVars : [
 		'keyInput',
 		'valueInput',

--- a/source/Teapot-Tools/TeaKeyValueList.class.st
+++ b/source/Teapot-Tools/TeaKeyValueList.class.st
@@ -3,7 +3,7 @@ I'm built up from a dynamically extensible list of other components.
 "
 Class {
 	#name : #TeaKeyValueList,
-	#superclass : #DynamicComposablePresenter,
+	#superclass : #DynamicComposableModel,
 	#instVars : [
 		'models'
 	],

--- a/source/Teapot-Tools/TeaRequestBodyTabs.class.st
+++ b/source/Teapot-Tools/TeaRequestBodyTabs.class.st
@@ -3,7 +3,7 @@ I graphically represent a request body that can be viewed in multiple ways.
 "
 Class {
 	#name : #TeaRequestBodyTabs,
-	#superclass : #ComposablePresenter,
+	#superclass : #ComposableModel,
 	#instVars : [
 		'requestBody',
 		'label',
@@ -50,12 +50,12 @@ TeaRequestBodyTabs >> newRequestBody [
 			(self newTab
 				label: self rawTabTitle;
 				closeable: false;
-				presenter: raw);
+				model: raw);
 		addTab:
 			(self newTab
 				label: self formTabTitle;
 				closeable: false;
-				presenter: form);
+				model: form);
 		whenTabSelected: [ :selected | 
 			selected label = self formTabTitle
 				ifTrue: [ form updateKeyValus: ('?' , raw text) asUrl query ]

--- a/source/Teapot-Tools/Teaspoon.class.st
+++ b/source/Teapot-Tools/Teaspoon.class.st
@@ -3,7 +3,7 @@ I provide a graphical interface for quickly testing and excesising routes. Right
 "
 Class {
 	#name : #Teaspoon,
-	#superclass : #ComposablePresenter,
+	#superclass : #ComposableModel,
 	#instVars : [
 		'urlInput',
 		'contentTypeDropList',


### PR DESCRIPTION
Restored some Pharo 7 deprecated code from imported code to fix tools on Pharo 6.1. 